### PR TITLE
Regenerating after resource_name added to CreateAclRequestData

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 INIT_DIR=../kafka-rest-sdk-go/
 GENERATOR_DIR=../openapi-generator
-OPENAPI_SPEC_DIR=../kafka-rest/api/v3/kafka-rest-v3-spec.yaml
+OPENAPI_SPEC_DIR=../kafka-rest/api/v3/openapi.yaml
 SDK_OUTPUT_DIR=../kafka-rest-sdk-go/kafkarestv3
 
 

--- a/kafkarestv3/api/openapi.yaml
+++ b/kafkarestv3/api/openapi.yaml
@@ -3629,9 +3629,12 @@ components:
       example:
         principal: principal
         host: host
+        resource_name: resource_name
       properties:
         resource_type:
           $ref: '#/components/schemas/AclResourceType'
+        resource_name:
+          type: string
         pattern_type:
           $ref: '#/components/schemas/AclPatternType'
         principal:

--- a/kafkarestv3/api_acl.go
+++ b/kafkarestv3/api_acl.go
@@ -11,12 +11,11 @@ package kafkarestv3
 
 import (
 	_context "context"
+	"github.com/antihax/optional"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
-
-	"github.com/antihax/optional"
 )
 
 // Linger please

--- a/kafkarestv3/docs/CreateAclRequestData.md
+++ b/kafkarestv3/docs/CreateAclRequestData.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ResourceType** | [**AclResourceType**](AclResourceType.md) |  | 
+**ResourceName** | **string** |  | 
 **PatternType** | [**AclPatternType**](AclPatternType.md) |  | 
 **Principal** | **string** |  | 
 **Host** | **string** |  | 

--- a/kafkarestv3/model_create_acl_request_data.go
+++ b/kafkarestv3/model_create_acl_request_data.go
@@ -11,6 +11,7 @@ package kafkarestv3
 // CreateAclRequestData struct for CreateAclRequestData
 type CreateAclRequestData struct {
 	ResourceType AclResourceType `json:"resource_type"`
+	ResourceName string `json:"resource_name"`
 	PatternType AclPatternType `json:"pattern_type"`
 	Principal string `json:"principal"`
 	Host string `json:"host"`


### PR DESCRIPTION
- Followed the instructions in README.md to apply the change to CreateAclRequestData in https://github.com/confluentinc/kafka-rest/pull/783 (addition of resource_name)
- kafka-rest-v3-spec.yaml has evidently been renamed to openapi.yaml, so updated that.

there were lots of white space changes in api_acl.go. They were almost all due to the difference between running `go fmt` and not. i erred on the side of avoiding white space changes, and api_acl.go is the result of the openapi-generator generated code with go fmt additionally run on it. There were white space changes to client.go as well, but i reverted that file entirely.

I noticed that if i run `go fmt` on the entire code, most of the files change, so for some reason there is a minority of files (including api_acl.go) that have go fmt applied. this should all be normalized, but a job for another PR.