### PR TITLE
Added resource_name to AclData

### DIFF
--- a/kafkarestv3/api/openapi.yaml
+++ b/kafkarestv3/api/openapi.yaml
@@ -3879,6 +3879,8 @@ components:
           type: string
         resource_type:
           $ref: '#/components/schemas/AclResourceType'
+        resource_name:
+          type: string
         pattern_type:
           $ref: '#/components/schemas/AclPatternType'
         principal:

--- a/kafkarestv3/docs/AclData.md
+++ b/kafkarestv3/docs/AclData.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **Metadata** | [**ResourceMetadata**](ResourceMetadata.md) |  | 
 **ClusterId** | **string** |  | 
 **ResourceType** | [**AclResourceType**](AclResourceType.md) |  | 
+**ResourceName** | **string** |  | 
 **PatternType** | [**AclPatternType**](AclPatternType.md) |  | 
 **Principal** | **string** |  | 
 **Host** | **string** |  | 

--- a/kafkarestv3/docs/AclDataAllOf.md
+++ b/kafkarestv3/docs/AclDataAllOf.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ClusterId** | **string** |  | 
 **ResourceType** | [**AclResourceType**](AclResourceType.md) |  | 
+**ResourceName** | **string** |  | 
 **PatternType** | [**AclPatternType**](AclPatternType.md) |  | 
 **Principal** | **string** |  | 
 **Host** | **string** |  | 

--- a/kafkarestv3/model_acl_data.go
+++ b/kafkarestv3/model_acl_data.go
@@ -14,6 +14,7 @@ type AclData struct {
 	Metadata ResourceMetadata `json:"metadata"`
 	ClusterId string `json:"cluster_id"`
 	ResourceType AclResourceType `json:"resource_type"`
+	ResourceName string `json:"resource_name"`
 	PatternType AclPatternType `json:"pattern_type"`
 	Principal string `json:"principal"`
 	Host string `json:"host"`

--- a/kafkarestv3/model_acl_data_all_of.go
+++ b/kafkarestv3/model_acl_data_all_of.go
@@ -12,6 +12,7 @@ package kafkarestv3
 type AclDataAllOf struct {
 	ClusterId string `json:"cluster_id"`
 	ResourceType AclResourceType `json:"resource_type"`
+	ResourceName string `json:"resource_name"`
 	PatternType AclPatternType `json:"pattern_type"`
 	Principal string `json:"principal"`
 	Host string `json:"host"`


### PR DESCRIPTION
generated as per instructions in README.md with `go fmt` applied in an ad-hoc manner to get rid of white-space diffs.