### PR TITLE
Reverting bad import from make gen-mock

### DIFF
--- a/kafkarestv3/mock/api_acl.go
+++ b/kafkarestv3/mock/api_acl.go
@@ -5,44 +5,45 @@
 package mock
 
 import (
-	command_line_arguments "command-line-arguments"
 	context "context"
 	net_http "net/http"
 	sync "sync"
+
+	github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3 "github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 )
 
 // ACLApi is a mock of ACLApi interface
 type ACLApi struct {
 	lockClustersClusterIdAclsDelete sync.Mutex
-	ClustersClusterIdAclsDeleteFunc func(ctx context.Context, clusterId string, localVarOptionals *command_line_arguments.ClustersClusterIdAclsDeleteOpts) (command_line_arguments.InlineResponse200, *net_http.Response, error)
+	ClustersClusterIdAclsDeleteFunc func(ctx context.Context, clusterId string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdAclsDeleteOpts) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.InlineResponse200, *net_http.Response, error)
 
 	lockClustersClusterIdAclsGet sync.Mutex
-	ClustersClusterIdAclsGetFunc func(ctx context.Context, clusterId string, localVarOptionals *command_line_arguments.ClustersClusterIdAclsGetOpts) (command_line_arguments.AclDataList, *net_http.Response, error)
+	ClustersClusterIdAclsGetFunc func(ctx context.Context, clusterId string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdAclsGetOpts) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.AclDataList, *net_http.Response, error)
 
 	lockClustersClusterIdAclsPost sync.Mutex
-	ClustersClusterIdAclsPostFunc func(ctx context.Context, clusterId string, localVarOptionals *command_line_arguments.ClustersClusterIdAclsPostOpts) (*net_http.Response, error)
+	ClustersClusterIdAclsPostFunc func(ctx context.Context, clusterId string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdAclsPostOpts) (*net_http.Response, error)
 
 	calls struct {
 		ClustersClusterIdAclsDelete []struct {
 			Ctx               context.Context
 			ClusterId         string
-			LocalVarOptionals *command_line_arguments.ClustersClusterIdAclsDeleteOpts
+			LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdAclsDeleteOpts
 		}
 		ClustersClusterIdAclsGet []struct {
 			Ctx               context.Context
 			ClusterId         string
-			LocalVarOptionals *command_line_arguments.ClustersClusterIdAclsGetOpts
+			LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdAclsGetOpts
 		}
 		ClustersClusterIdAclsPost []struct {
 			Ctx               context.Context
 			ClusterId         string
-			LocalVarOptionals *command_line_arguments.ClustersClusterIdAclsPostOpts
+			LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdAclsPostOpts
 		}
 	}
 }
 
 // ClustersClusterIdAclsDelete mocks base method by wrapping the associated func.
-func (m *ACLApi) ClustersClusterIdAclsDelete(ctx context.Context, clusterId string, localVarOptionals *command_line_arguments.ClustersClusterIdAclsDeleteOpts) (command_line_arguments.InlineResponse200, *net_http.Response, error) {
+func (m *ACLApi) ClustersClusterIdAclsDelete(ctx context.Context, clusterId string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdAclsDeleteOpts) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.InlineResponse200, *net_http.Response, error) {
 	m.lockClustersClusterIdAclsDelete.Lock()
 	defer m.lockClustersClusterIdAclsDelete.Unlock()
 
@@ -53,7 +54,7 @@ func (m *ACLApi) ClustersClusterIdAclsDelete(ctx context.Context, clusterId stri
 	call := struct {
 		Ctx               context.Context
 		ClusterId         string
-		LocalVarOptionals *command_line_arguments.ClustersClusterIdAclsDeleteOpts
+		LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdAclsDeleteOpts
 	}{
 		Ctx:               ctx,
 		ClusterId:         clusterId,
@@ -77,7 +78,7 @@ func (m *ACLApi) ClustersClusterIdAclsDeleteCalled() bool {
 func (m *ACLApi) ClustersClusterIdAclsDeleteCalls() []struct {
 	Ctx               context.Context
 	ClusterId         string
-	LocalVarOptionals *command_line_arguments.ClustersClusterIdAclsDeleteOpts
+	LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdAclsDeleteOpts
 } {
 	m.lockClustersClusterIdAclsDelete.Lock()
 	defer m.lockClustersClusterIdAclsDelete.Unlock()
@@ -86,7 +87,7 @@ func (m *ACLApi) ClustersClusterIdAclsDeleteCalls() []struct {
 }
 
 // ClustersClusterIdAclsGet mocks base method by wrapping the associated func.
-func (m *ACLApi) ClustersClusterIdAclsGet(ctx context.Context, clusterId string, localVarOptionals *command_line_arguments.ClustersClusterIdAclsGetOpts) (command_line_arguments.AclDataList, *net_http.Response, error) {
+func (m *ACLApi) ClustersClusterIdAclsGet(ctx context.Context, clusterId string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdAclsGetOpts) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.AclDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdAclsGet.Lock()
 	defer m.lockClustersClusterIdAclsGet.Unlock()
 
@@ -97,7 +98,7 @@ func (m *ACLApi) ClustersClusterIdAclsGet(ctx context.Context, clusterId string,
 	call := struct {
 		Ctx               context.Context
 		ClusterId         string
-		LocalVarOptionals *command_line_arguments.ClustersClusterIdAclsGetOpts
+		LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdAclsGetOpts
 	}{
 		Ctx:               ctx,
 		ClusterId:         clusterId,
@@ -121,7 +122,7 @@ func (m *ACLApi) ClustersClusterIdAclsGetCalled() bool {
 func (m *ACLApi) ClustersClusterIdAclsGetCalls() []struct {
 	Ctx               context.Context
 	ClusterId         string
-	LocalVarOptionals *command_line_arguments.ClustersClusterIdAclsGetOpts
+	LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdAclsGetOpts
 } {
 	m.lockClustersClusterIdAclsGet.Lock()
 	defer m.lockClustersClusterIdAclsGet.Unlock()
@@ -130,7 +131,7 @@ func (m *ACLApi) ClustersClusterIdAclsGetCalls() []struct {
 }
 
 // ClustersClusterIdAclsPost mocks base method by wrapping the associated func.
-func (m *ACLApi) ClustersClusterIdAclsPost(ctx context.Context, clusterId string, localVarOptionals *command_line_arguments.ClustersClusterIdAclsPostOpts) (*net_http.Response, error) {
+func (m *ACLApi) ClustersClusterIdAclsPost(ctx context.Context, clusterId string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdAclsPostOpts) (*net_http.Response, error) {
 	m.lockClustersClusterIdAclsPost.Lock()
 	defer m.lockClustersClusterIdAclsPost.Unlock()
 
@@ -141,7 +142,7 @@ func (m *ACLApi) ClustersClusterIdAclsPost(ctx context.Context, clusterId string
 	call := struct {
 		Ctx               context.Context
 		ClusterId         string
-		LocalVarOptionals *command_line_arguments.ClustersClusterIdAclsPostOpts
+		LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdAclsPostOpts
 	}{
 		Ctx:               ctx,
 		ClusterId:         clusterId,
@@ -165,7 +166,7 @@ func (m *ACLApi) ClustersClusterIdAclsPostCalled() bool {
 func (m *ACLApi) ClustersClusterIdAclsPostCalls() []struct {
 	Ctx               context.Context
 	ClusterId         string
-	LocalVarOptionals *command_line_arguments.ClustersClusterIdAclsPostOpts
+	LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdAclsPostOpts
 } {
 	m.lockClustersClusterIdAclsPost.Lock()
 	defer m.lockClustersClusterIdAclsPost.Unlock()

--- a/kafkarestv3/mock/api_broker.go
+++ b/kafkarestv3/mock/api_broker.go
@@ -5,22 +5,23 @@
 package mock
 
 import (
-	command_line_arguments "command-line-arguments"
 	context "context"
 	net_http "net/http"
 	sync "sync"
+
+	github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3 "github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 )
 
 // BrokerApi is a mock of BrokerApi interface
 type BrokerApi struct {
 	lockClustersClusterIdBrokersBrokerIdGet sync.Mutex
-	ClustersClusterIdBrokersBrokerIdGetFunc func(ctx context.Context, clusterId string, brokerId int32) (command_line_arguments.BrokerData, *net_http.Response, error)
+	ClustersClusterIdBrokersBrokerIdGetFunc func(ctx context.Context, clusterId string, brokerId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.BrokerData, *net_http.Response, error)
 
 	lockClustersClusterIdBrokersBrokerIdPartitionReplicasGet sync.Mutex
-	ClustersClusterIdBrokersBrokerIdPartitionReplicasGetFunc func(ctx context.Context, clusterId string, brokerId int32) (command_line_arguments.ReplicaDataList, *net_http.Response, error)
+	ClustersClusterIdBrokersBrokerIdPartitionReplicasGetFunc func(ctx context.Context, clusterId string, brokerId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ReplicaDataList, *net_http.Response, error)
 
 	lockClustersClusterIdBrokersGet sync.Mutex
-	ClustersClusterIdBrokersGetFunc func(ctx context.Context, clusterId string) (command_line_arguments.BrokerDataList, *net_http.Response, error)
+	ClustersClusterIdBrokersGetFunc func(ctx context.Context, clusterId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.BrokerDataList, *net_http.Response, error)
 
 	calls struct {
 		ClustersClusterIdBrokersBrokerIdGet []struct {
@@ -41,7 +42,7 @@ type BrokerApi struct {
 }
 
 // ClustersClusterIdBrokersBrokerIdGet mocks base method by wrapping the associated func.
-func (m *BrokerApi) ClustersClusterIdBrokersBrokerIdGet(ctx context.Context, clusterId string, brokerId int32) (command_line_arguments.BrokerData, *net_http.Response, error) {
+func (m *BrokerApi) ClustersClusterIdBrokersBrokerIdGet(ctx context.Context, clusterId string, brokerId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.BrokerData, *net_http.Response, error) {
 	m.lockClustersClusterIdBrokersBrokerIdGet.Lock()
 	defer m.lockClustersClusterIdBrokersBrokerIdGet.Unlock()
 
@@ -85,7 +86,7 @@ func (m *BrokerApi) ClustersClusterIdBrokersBrokerIdGetCalls() []struct {
 }
 
 // ClustersClusterIdBrokersBrokerIdPartitionReplicasGet mocks base method by wrapping the associated func.
-func (m *BrokerApi) ClustersClusterIdBrokersBrokerIdPartitionReplicasGet(ctx context.Context, clusterId string, brokerId int32) (command_line_arguments.ReplicaDataList, *net_http.Response, error) {
+func (m *BrokerApi) ClustersClusterIdBrokersBrokerIdPartitionReplicasGet(ctx context.Context, clusterId string, brokerId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ReplicaDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdBrokersBrokerIdPartitionReplicasGet.Lock()
 	defer m.lockClustersClusterIdBrokersBrokerIdPartitionReplicasGet.Unlock()
 
@@ -129,7 +130,7 @@ func (m *BrokerApi) ClustersClusterIdBrokersBrokerIdPartitionReplicasGetCalls() 
 }
 
 // ClustersClusterIdBrokersGet mocks base method by wrapping the associated func.
-func (m *BrokerApi) ClustersClusterIdBrokersGet(ctx context.Context, clusterId string) (command_line_arguments.BrokerDataList, *net_http.Response, error) {
+func (m *BrokerApi) ClustersClusterIdBrokersGet(ctx context.Context, clusterId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.BrokerDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdBrokersGet.Lock()
 	defer m.lockClustersClusterIdBrokersGet.Unlock()
 

--- a/kafkarestv3/mock/api_cluster.go
+++ b/kafkarestv3/mock/api_cluster.go
@@ -5,19 +5,20 @@
 package mock
 
 import (
-	command_line_arguments "command-line-arguments"
 	context "context"
 	net_http "net/http"
 	sync "sync"
+
+	github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3 "github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 )
 
 // ClusterApi is a mock of ClusterApi interface
 type ClusterApi struct {
 	lockClustersClusterIdGet sync.Mutex
-	ClustersClusterIdGetFunc func(ctx context.Context, clusterId string) (command_line_arguments.ClusterData, *net_http.Response, error)
+	ClustersClusterIdGetFunc func(ctx context.Context, clusterId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClusterData, *net_http.Response, error)
 
 	lockClustersGet sync.Mutex
-	ClustersGetFunc func(ctx context.Context) (command_line_arguments.ClusterDataList, *net_http.Response, error)
+	ClustersGetFunc func(ctx context.Context) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClusterDataList, *net_http.Response, error)
 
 	calls struct {
 		ClustersClusterIdGet []struct {
@@ -31,7 +32,7 @@ type ClusterApi struct {
 }
 
 // ClustersClusterIdGet mocks base method by wrapping the associated func.
-func (m *ClusterApi) ClustersClusterIdGet(ctx context.Context, clusterId string) (command_line_arguments.ClusterData, *net_http.Response, error) {
+func (m *ClusterApi) ClustersClusterIdGet(ctx context.Context, clusterId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClusterData, *net_http.Response, error) {
 	m.lockClustersClusterIdGet.Lock()
 	defer m.lockClustersClusterIdGet.Unlock()
 
@@ -72,7 +73,7 @@ func (m *ClusterApi) ClustersClusterIdGetCalls() []struct {
 }
 
 // ClustersGet mocks base method by wrapping the associated func.
-func (m *ClusterApi) ClustersGet(ctx context.Context) (command_line_arguments.ClusterDataList, *net_http.Response, error) {
+func (m *ClusterApi) ClustersGet(ctx context.Context) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClusterDataList, *net_http.Response, error) {
 	m.lockClustersGet.Lock()
 	defer m.lockClustersGet.Unlock()
 

--- a/kafkarestv3/mock/api_configs.go
+++ b/kafkarestv3/mock/api_configs.go
@@ -5,58 +5,59 @@
 package mock
 
 import (
-	command_line_arguments "command-line-arguments"
 	context "context"
 	net_http "net/http"
 	sync "sync"
+
+	github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3 "github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 )
 
 // ConfigsApi is a mock of ConfigsApi interface
 type ConfigsApi struct {
 	lockClustersClusterIdBrokerConfigsGet sync.Mutex
-	ClustersClusterIdBrokerConfigsGetFunc func(ctx context.Context, clusterId string) (command_line_arguments.ClusterConfigDataList, *net_http.Response, error)
+	ClustersClusterIdBrokerConfigsGetFunc func(ctx context.Context, clusterId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClusterConfigDataList, *net_http.Response, error)
 
 	lockClustersClusterIdBrokerConfigsNameDelete sync.Mutex
 	ClustersClusterIdBrokerConfigsNameDeleteFunc func(ctx context.Context, clusterId, name string) (*net_http.Response, error)
 
 	lockClustersClusterIdBrokerConfigsNameGet sync.Mutex
-	ClustersClusterIdBrokerConfigsNameGetFunc func(ctx context.Context, clusterId, name string) (command_line_arguments.ClusterConfigData, *net_http.Response, error)
+	ClustersClusterIdBrokerConfigsNameGetFunc func(ctx context.Context, clusterId, name string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClusterConfigData, *net_http.Response, error)
 
 	lockClustersClusterIdBrokerConfigsNamePut sync.Mutex
-	ClustersClusterIdBrokerConfigsNamePutFunc func(ctx context.Context, clusterId, name string, localVarOptionals *command_line_arguments.ClustersClusterIdBrokerConfigsNamePutOpts) (*net_http.Response, error)
+	ClustersClusterIdBrokerConfigsNamePutFunc func(ctx context.Context, clusterId, name string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokerConfigsNamePutOpts) (*net_http.Response, error)
 
 	lockClustersClusterIdBrokerConfigsalterPost sync.Mutex
-	ClustersClusterIdBrokerConfigsalterPostFunc func(ctx context.Context, clusterId string, localVarOptionals *command_line_arguments.ClustersClusterIdBrokerConfigsalterPostOpts) (*net_http.Response, error)
+	ClustersClusterIdBrokerConfigsalterPostFunc func(ctx context.Context, clusterId string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokerConfigsalterPostOpts) (*net_http.Response, error)
 
 	lockClustersClusterIdBrokersBrokerIdConfigsGet sync.Mutex
-	ClustersClusterIdBrokersBrokerIdConfigsGetFunc func(ctx context.Context, clusterId string, brokerId int32) (command_line_arguments.BrokerConfigDataList, *net_http.Response, error)
+	ClustersClusterIdBrokersBrokerIdConfigsGetFunc func(ctx context.Context, clusterId string, brokerId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.BrokerConfigDataList, *net_http.Response, error)
 
 	lockClustersClusterIdBrokersBrokerIdConfigsNameDelete sync.Mutex
 	ClustersClusterIdBrokersBrokerIdConfigsNameDeleteFunc func(ctx context.Context, clusterId string, brokerId int32, name string) (*net_http.Response, error)
 
 	lockClustersClusterIdBrokersBrokerIdConfigsNameGet sync.Mutex
-	ClustersClusterIdBrokersBrokerIdConfigsNameGetFunc func(ctx context.Context, clusterId string, brokerId int32, name string) (command_line_arguments.BrokerConfigData, *net_http.Response, error)
+	ClustersClusterIdBrokersBrokerIdConfigsNameGetFunc func(ctx context.Context, clusterId string, brokerId int32, name string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.BrokerConfigData, *net_http.Response, error)
 
 	lockClustersClusterIdBrokersBrokerIdConfigsNamePut sync.Mutex
-	ClustersClusterIdBrokersBrokerIdConfigsNamePutFunc func(ctx context.Context, clusterId string, brokerId int32, name string, localVarOptionals *command_line_arguments.ClustersClusterIdBrokersBrokerIdConfigsNamePutOpts) (*net_http.Response, error)
+	ClustersClusterIdBrokersBrokerIdConfigsNamePutFunc func(ctx context.Context, clusterId string, brokerId int32, name string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokersBrokerIdConfigsNamePutOpts) (*net_http.Response, error)
 
 	lockClustersClusterIdBrokersBrokerIdConfigsalterPost sync.Mutex
-	ClustersClusterIdBrokersBrokerIdConfigsalterPostFunc func(ctx context.Context, clusterId string, brokerId int32, localVarOptionals *command_line_arguments.ClustersClusterIdBrokersBrokerIdConfigsalterPostOpts) (*net_http.Response, error)
+	ClustersClusterIdBrokersBrokerIdConfigsalterPostFunc func(ctx context.Context, clusterId string, brokerId int32, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokersBrokerIdConfigsalterPostOpts) (*net_http.Response, error)
 
 	lockClustersClusterIdTopicsTopicNameConfigsGet sync.Mutex
-	ClustersClusterIdTopicsTopicNameConfigsGetFunc func(ctx context.Context, clusterId, topicName string) (command_line_arguments.TopicConfigDataList, *net_http.Response, error)
+	ClustersClusterIdTopicsTopicNameConfigsGetFunc func(ctx context.Context, clusterId, topicName string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.TopicConfigDataList, *net_http.Response, error)
 
 	lockClustersClusterIdTopicsTopicNameConfigsNameDelete sync.Mutex
 	ClustersClusterIdTopicsTopicNameConfigsNameDeleteFunc func(ctx context.Context, clusterId, topicName, name string) (*net_http.Response, error)
 
 	lockClustersClusterIdTopicsTopicNameConfigsNameGet sync.Mutex
-	ClustersClusterIdTopicsTopicNameConfigsNameGetFunc func(ctx context.Context, clusterId, topicName, name string) (command_line_arguments.TopicConfigData, *net_http.Response, error)
+	ClustersClusterIdTopicsTopicNameConfigsNameGetFunc func(ctx context.Context, clusterId, topicName, name string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.TopicConfigData, *net_http.Response, error)
 
 	lockClustersClusterIdTopicsTopicNameConfigsNamePut sync.Mutex
-	ClustersClusterIdTopicsTopicNameConfigsNamePutFunc func(ctx context.Context, clusterId, topicName, name string, localVarOptionals *command_line_arguments.ClustersClusterIdTopicsTopicNameConfigsNamePutOpts) (*net_http.Response, error)
+	ClustersClusterIdTopicsTopicNameConfigsNamePutFunc func(ctx context.Context, clusterId, topicName, name string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdTopicsTopicNameConfigsNamePutOpts) (*net_http.Response, error)
 
 	lockClustersClusterIdTopicsTopicNameConfigsalterPost sync.Mutex
-	ClustersClusterIdTopicsTopicNameConfigsalterPostFunc func(ctx context.Context, clusterId, topicName string, localVarOptionals *command_line_arguments.ClustersClusterIdTopicsTopicNameConfigsalterPostOpts) (*net_http.Response, error)
+	ClustersClusterIdTopicsTopicNameConfigsalterPostFunc func(ctx context.Context, clusterId, topicName string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdTopicsTopicNameConfigsalterPostOpts) (*net_http.Response, error)
 
 	calls struct {
 		ClustersClusterIdBrokerConfigsGet []struct {
@@ -77,12 +78,12 @@ type ConfigsApi struct {
 			Ctx               context.Context
 			ClusterId         string
 			Name              string
-			LocalVarOptionals *command_line_arguments.ClustersClusterIdBrokerConfigsNamePutOpts
+			LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokerConfigsNamePutOpts
 		}
 		ClustersClusterIdBrokerConfigsalterPost []struct {
 			Ctx               context.Context
 			ClusterId         string
-			LocalVarOptionals *command_line_arguments.ClustersClusterIdBrokerConfigsalterPostOpts
+			LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokerConfigsalterPostOpts
 		}
 		ClustersClusterIdBrokersBrokerIdConfigsGet []struct {
 			Ctx       context.Context
@@ -106,13 +107,13 @@ type ConfigsApi struct {
 			ClusterId         string
 			BrokerId          int32
 			Name              string
-			LocalVarOptionals *command_line_arguments.ClustersClusterIdBrokersBrokerIdConfigsNamePutOpts
+			LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokersBrokerIdConfigsNamePutOpts
 		}
 		ClustersClusterIdBrokersBrokerIdConfigsalterPost []struct {
 			Ctx               context.Context
 			ClusterId         string
 			BrokerId          int32
-			LocalVarOptionals *command_line_arguments.ClustersClusterIdBrokersBrokerIdConfigsalterPostOpts
+			LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokersBrokerIdConfigsalterPostOpts
 		}
 		ClustersClusterIdTopicsTopicNameConfigsGet []struct {
 			Ctx       context.Context
@@ -136,19 +137,19 @@ type ConfigsApi struct {
 			ClusterId         string
 			TopicName         string
 			Name              string
-			LocalVarOptionals *command_line_arguments.ClustersClusterIdTopicsTopicNameConfigsNamePutOpts
+			LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdTopicsTopicNameConfigsNamePutOpts
 		}
 		ClustersClusterIdTopicsTopicNameConfigsalterPost []struct {
 			Ctx               context.Context
 			ClusterId         string
 			TopicName         string
-			LocalVarOptionals *command_line_arguments.ClustersClusterIdTopicsTopicNameConfigsalterPostOpts
+			LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdTopicsTopicNameConfigsalterPostOpts
 		}
 	}
 }
 
 // ClustersClusterIdBrokerConfigsGet mocks base method by wrapping the associated func.
-func (m *ConfigsApi) ClustersClusterIdBrokerConfigsGet(ctx context.Context, clusterId string) (command_line_arguments.ClusterConfigDataList, *net_http.Response, error) {
+func (m *ConfigsApi) ClustersClusterIdBrokerConfigsGet(ctx context.Context, clusterId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClusterConfigDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdBrokerConfigsGet.Lock()
 	defer m.lockClustersClusterIdBrokerConfigsGet.Unlock()
 
@@ -233,7 +234,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokerConfigsNameDeleteCalls() []struct {
 }
 
 // ClustersClusterIdBrokerConfigsNameGet mocks base method by wrapping the associated func.
-func (m *ConfigsApi) ClustersClusterIdBrokerConfigsNameGet(ctx context.Context, clusterId, name string) (command_line_arguments.ClusterConfigData, *net_http.Response, error) {
+func (m *ConfigsApi) ClustersClusterIdBrokerConfigsNameGet(ctx context.Context, clusterId, name string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClusterConfigData, *net_http.Response, error) {
 	m.lockClustersClusterIdBrokerConfigsNameGet.Lock()
 	defer m.lockClustersClusterIdBrokerConfigsNameGet.Unlock()
 
@@ -277,7 +278,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokerConfigsNameGetCalls() []struct {
 }
 
 // ClustersClusterIdBrokerConfigsNamePut mocks base method by wrapping the associated func.
-func (m *ConfigsApi) ClustersClusterIdBrokerConfigsNamePut(ctx context.Context, clusterId, name string, localVarOptionals *command_line_arguments.ClustersClusterIdBrokerConfigsNamePutOpts) (*net_http.Response, error) {
+func (m *ConfigsApi) ClustersClusterIdBrokerConfigsNamePut(ctx context.Context, clusterId, name string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokerConfigsNamePutOpts) (*net_http.Response, error) {
 	m.lockClustersClusterIdBrokerConfigsNamePut.Lock()
 	defer m.lockClustersClusterIdBrokerConfigsNamePut.Unlock()
 
@@ -289,7 +290,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokerConfigsNamePut(ctx context.Context, 
 		Ctx               context.Context
 		ClusterId         string
 		Name              string
-		LocalVarOptionals *command_line_arguments.ClustersClusterIdBrokerConfigsNamePutOpts
+		LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokerConfigsNamePutOpts
 	}{
 		Ctx:               ctx,
 		ClusterId:         clusterId,
@@ -315,7 +316,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokerConfigsNamePutCalls() []struct {
 	Ctx               context.Context
 	ClusterId         string
 	Name              string
-	LocalVarOptionals *command_line_arguments.ClustersClusterIdBrokerConfigsNamePutOpts
+	LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokerConfigsNamePutOpts
 } {
 	m.lockClustersClusterIdBrokerConfigsNamePut.Lock()
 	defer m.lockClustersClusterIdBrokerConfigsNamePut.Unlock()
@@ -324,7 +325,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokerConfigsNamePutCalls() []struct {
 }
 
 // ClustersClusterIdBrokerConfigsalterPost mocks base method by wrapping the associated func.
-func (m *ConfigsApi) ClustersClusterIdBrokerConfigsalterPost(ctx context.Context, clusterId string, localVarOptionals *command_line_arguments.ClustersClusterIdBrokerConfigsalterPostOpts) (*net_http.Response, error) {
+func (m *ConfigsApi) ClustersClusterIdBrokerConfigsalterPost(ctx context.Context, clusterId string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokerConfigsalterPostOpts) (*net_http.Response, error) {
 	m.lockClustersClusterIdBrokerConfigsalterPost.Lock()
 	defer m.lockClustersClusterIdBrokerConfigsalterPost.Unlock()
 
@@ -335,7 +336,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokerConfigsalterPost(ctx context.Context
 	call := struct {
 		Ctx               context.Context
 		ClusterId         string
-		LocalVarOptionals *command_line_arguments.ClustersClusterIdBrokerConfigsalterPostOpts
+		LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokerConfigsalterPostOpts
 	}{
 		Ctx:               ctx,
 		ClusterId:         clusterId,
@@ -359,7 +360,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokerConfigsalterPostCalled() bool {
 func (m *ConfigsApi) ClustersClusterIdBrokerConfigsalterPostCalls() []struct {
 	Ctx               context.Context
 	ClusterId         string
-	LocalVarOptionals *command_line_arguments.ClustersClusterIdBrokerConfigsalterPostOpts
+	LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokerConfigsalterPostOpts
 } {
 	m.lockClustersClusterIdBrokerConfigsalterPost.Lock()
 	defer m.lockClustersClusterIdBrokerConfigsalterPost.Unlock()
@@ -368,7 +369,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokerConfigsalterPostCalls() []struct {
 }
 
 // ClustersClusterIdBrokersBrokerIdConfigsGet mocks base method by wrapping the associated func.
-func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsGet(ctx context.Context, clusterId string, brokerId int32) (command_line_arguments.BrokerConfigDataList, *net_http.Response, error) {
+func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsGet(ctx context.Context, clusterId string, brokerId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.BrokerConfigDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdBrokersBrokerIdConfigsGet.Lock()
 	defer m.lockClustersClusterIdBrokersBrokerIdConfigsGet.Unlock()
 
@@ -459,7 +460,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsNameDeleteCalls() []
 }
 
 // ClustersClusterIdBrokersBrokerIdConfigsNameGet mocks base method by wrapping the associated func.
-func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsNameGet(ctx context.Context, clusterId string, brokerId int32, name string) (command_line_arguments.BrokerConfigData, *net_http.Response, error) {
+func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsNameGet(ctx context.Context, clusterId string, brokerId int32, name string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.BrokerConfigData, *net_http.Response, error) {
 	m.lockClustersClusterIdBrokersBrokerIdConfigsNameGet.Lock()
 	defer m.lockClustersClusterIdBrokersBrokerIdConfigsNameGet.Unlock()
 
@@ -506,7 +507,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsNameGetCalls() []str
 }
 
 // ClustersClusterIdBrokersBrokerIdConfigsNamePut mocks base method by wrapping the associated func.
-func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsNamePut(ctx context.Context, clusterId string, brokerId int32, name string, localVarOptionals *command_line_arguments.ClustersClusterIdBrokersBrokerIdConfigsNamePutOpts) (*net_http.Response, error) {
+func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsNamePut(ctx context.Context, clusterId string, brokerId int32, name string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokersBrokerIdConfigsNamePutOpts) (*net_http.Response, error) {
 	m.lockClustersClusterIdBrokersBrokerIdConfigsNamePut.Lock()
 	defer m.lockClustersClusterIdBrokersBrokerIdConfigsNamePut.Unlock()
 
@@ -519,7 +520,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsNamePut(ctx context.
 		ClusterId         string
 		BrokerId          int32
 		Name              string
-		LocalVarOptionals *command_line_arguments.ClustersClusterIdBrokersBrokerIdConfigsNamePutOpts
+		LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokersBrokerIdConfigsNamePutOpts
 	}{
 		Ctx:               ctx,
 		ClusterId:         clusterId,
@@ -547,7 +548,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsNamePutCalls() []str
 	ClusterId         string
 	BrokerId          int32
 	Name              string
-	LocalVarOptionals *command_line_arguments.ClustersClusterIdBrokersBrokerIdConfigsNamePutOpts
+	LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokersBrokerIdConfigsNamePutOpts
 } {
 	m.lockClustersClusterIdBrokersBrokerIdConfigsNamePut.Lock()
 	defer m.lockClustersClusterIdBrokersBrokerIdConfigsNamePut.Unlock()
@@ -556,7 +557,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsNamePutCalls() []str
 }
 
 // ClustersClusterIdBrokersBrokerIdConfigsalterPost mocks base method by wrapping the associated func.
-func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsalterPost(ctx context.Context, clusterId string, brokerId int32, localVarOptionals *command_line_arguments.ClustersClusterIdBrokersBrokerIdConfigsalterPostOpts) (*net_http.Response, error) {
+func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsalterPost(ctx context.Context, clusterId string, brokerId int32, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokersBrokerIdConfigsalterPostOpts) (*net_http.Response, error) {
 	m.lockClustersClusterIdBrokersBrokerIdConfigsalterPost.Lock()
 	defer m.lockClustersClusterIdBrokersBrokerIdConfigsalterPost.Unlock()
 
@@ -568,7 +569,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsalterPost(ctx contex
 		Ctx               context.Context
 		ClusterId         string
 		BrokerId          int32
-		LocalVarOptionals *command_line_arguments.ClustersClusterIdBrokersBrokerIdConfigsalterPostOpts
+		LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokersBrokerIdConfigsalterPostOpts
 	}{
 		Ctx:               ctx,
 		ClusterId:         clusterId,
@@ -594,7 +595,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsalterPostCalls() []s
 	Ctx               context.Context
 	ClusterId         string
 	BrokerId          int32
-	LocalVarOptionals *command_line_arguments.ClustersClusterIdBrokersBrokerIdConfigsalterPostOpts
+	LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdBrokersBrokerIdConfigsalterPostOpts
 } {
 	m.lockClustersClusterIdBrokersBrokerIdConfigsalterPost.Lock()
 	defer m.lockClustersClusterIdBrokersBrokerIdConfigsalterPost.Unlock()
@@ -603,7 +604,7 @@ func (m *ConfigsApi) ClustersClusterIdBrokersBrokerIdConfigsalterPostCalls() []s
 }
 
 // ClustersClusterIdTopicsTopicNameConfigsGet mocks base method by wrapping the associated func.
-func (m *ConfigsApi) ClustersClusterIdTopicsTopicNameConfigsGet(ctx context.Context, clusterId, topicName string) (command_line_arguments.TopicConfigDataList, *net_http.Response, error) {
+func (m *ConfigsApi) ClustersClusterIdTopicsTopicNameConfigsGet(ctx context.Context, clusterId, topicName string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.TopicConfigDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdTopicsTopicNameConfigsGet.Lock()
 	defer m.lockClustersClusterIdTopicsTopicNameConfigsGet.Unlock()
 
@@ -694,7 +695,7 @@ func (m *ConfigsApi) ClustersClusterIdTopicsTopicNameConfigsNameDeleteCalls() []
 }
 
 // ClustersClusterIdTopicsTopicNameConfigsNameGet mocks base method by wrapping the associated func.
-func (m *ConfigsApi) ClustersClusterIdTopicsTopicNameConfigsNameGet(ctx context.Context, clusterId, topicName, name string) (command_line_arguments.TopicConfigData, *net_http.Response, error) {
+func (m *ConfigsApi) ClustersClusterIdTopicsTopicNameConfigsNameGet(ctx context.Context, clusterId, topicName, name string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.TopicConfigData, *net_http.Response, error) {
 	m.lockClustersClusterIdTopicsTopicNameConfigsNameGet.Lock()
 	defer m.lockClustersClusterIdTopicsTopicNameConfigsNameGet.Unlock()
 
@@ -741,7 +742,7 @@ func (m *ConfigsApi) ClustersClusterIdTopicsTopicNameConfigsNameGetCalls() []str
 }
 
 // ClustersClusterIdTopicsTopicNameConfigsNamePut mocks base method by wrapping the associated func.
-func (m *ConfigsApi) ClustersClusterIdTopicsTopicNameConfigsNamePut(ctx context.Context, clusterId, topicName, name string, localVarOptionals *command_line_arguments.ClustersClusterIdTopicsTopicNameConfigsNamePutOpts) (*net_http.Response, error) {
+func (m *ConfigsApi) ClustersClusterIdTopicsTopicNameConfigsNamePut(ctx context.Context, clusterId, topicName, name string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdTopicsTopicNameConfigsNamePutOpts) (*net_http.Response, error) {
 	m.lockClustersClusterIdTopicsTopicNameConfigsNamePut.Lock()
 	defer m.lockClustersClusterIdTopicsTopicNameConfigsNamePut.Unlock()
 
@@ -754,7 +755,7 @@ func (m *ConfigsApi) ClustersClusterIdTopicsTopicNameConfigsNamePut(ctx context.
 		ClusterId         string
 		TopicName         string
 		Name              string
-		LocalVarOptionals *command_line_arguments.ClustersClusterIdTopicsTopicNameConfigsNamePutOpts
+		LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdTopicsTopicNameConfigsNamePutOpts
 	}{
 		Ctx:               ctx,
 		ClusterId:         clusterId,
@@ -782,7 +783,7 @@ func (m *ConfigsApi) ClustersClusterIdTopicsTopicNameConfigsNamePutCalls() []str
 	ClusterId         string
 	TopicName         string
 	Name              string
-	LocalVarOptionals *command_line_arguments.ClustersClusterIdTopicsTopicNameConfigsNamePutOpts
+	LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdTopicsTopicNameConfigsNamePutOpts
 } {
 	m.lockClustersClusterIdTopicsTopicNameConfigsNamePut.Lock()
 	defer m.lockClustersClusterIdTopicsTopicNameConfigsNamePut.Unlock()
@@ -791,7 +792,7 @@ func (m *ConfigsApi) ClustersClusterIdTopicsTopicNameConfigsNamePutCalls() []str
 }
 
 // ClustersClusterIdTopicsTopicNameConfigsalterPost mocks base method by wrapping the associated func.
-func (m *ConfigsApi) ClustersClusterIdTopicsTopicNameConfigsalterPost(ctx context.Context, clusterId, topicName string, localVarOptionals *command_line_arguments.ClustersClusterIdTopicsTopicNameConfigsalterPostOpts) (*net_http.Response, error) {
+func (m *ConfigsApi) ClustersClusterIdTopicsTopicNameConfigsalterPost(ctx context.Context, clusterId, topicName string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdTopicsTopicNameConfigsalterPostOpts) (*net_http.Response, error) {
 	m.lockClustersClusterIdTopicsTopicNameConfigsalterPost.Lock()
 	defer m.lockClustersClusterIdTopicsTopicNameConfigsalterPost.Unlock()
 
@@ -803,7 +804,7 @@ func (m *ConfigsApi) ClustersClusterIdTopicsTopicNameConfigsalterPost(ctx contex
 		Ctx               context.Context
 		ClusterId         string
 		TopicName         string
-		LocalVarOptionals *command_line_arguments.ClustersClusterIdTopicsTopicNameConfigsalterPostOpts
+		LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdTopicsTopicNameConfigsalterPostOpts
 	}{
 		Ctx:               ctx,
 		ClusterId:         clusterId,
@@ -829,7 +830,7 @@ func (m *ConfigsApi) ClustersClusterIdTopicsTopicNameConfigsalterPostCalls() []s
 	Ctx               context.Context
 	ClusterId         string
 	TopicName         string
-	LocalVarOptionals *command_line_arguments.ClustersClusterIdTopicsTopicNameConfigsalterPostOpts
+	LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdTopicsTopicNameConfigsalterPostOpts
 } {
 	m.lockClustersClusterIdTopicsTopicNameConfigsalterPost.Lock()
 	defer m.lockClustersClusterIdTopicsTopicNameConfigsalterPost.Unlock()

--- a/kafkarestv3/mock/api_consumer_group.go
+++ b/kafkarestv3/mock/api_consumer_group.go
@@ -5,37 +5,38 @@
 package mock
 
 import (
-	command_line_arguments "command-line-arguments"
 	context "context"
 	net_http "net/http"
 	sync "sync"
+
+	github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3 "github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 )
 
 // ConsumerGroupApi is a mock of ConsumerGroupApi interface
 type ConsumerGroupApi struct {
 	lockClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsGet sync.Mutex
-	ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsGetFunc func(ctx context.Context, clusterId, consumerGroupId, consumerId string) (command_line_arguments.ConsumerAssignmentDataList, *net_http.Response, error)
+	ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsGetFunc func(ctx context.Context, clusterId, consumerGroupId, consumerId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerAssignmentDataList, *net_http.Response, error)
 
 	lockClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsTopicNamePartitionsPartitionIdGet sync.Mutex
-	ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsTopicNamePartitionsPartitionIdGetFunc func(ctx context.Context, clusterId, consumerGroupId, consumerId, topicName string, partitionId int32) (command_line_arguments.ConsumerAssignmentData, *net_http.Response, error)
+	ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsTopicNamePartitionsPartitionIdGetFunc func(ctx context.Context, clusterId, consumerGroupId, consumerId, topicName string, partitionId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerAssignmentData, *net_http.Response, error)
 
 	lockClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdGet sync.Mutex
-	ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdGetFunc func(ctx context.Context, clusterId, consumerGroupId, consumerId string) (command_line_arguments.ConsumerData, *net_http.Response, error)
+	ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdGetFunc func(ctx context.Context, clusterId, consumerGroupId, consumerId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerData, *net_http.Response, error)
 
 	lockClustersClusterIdConsumerGroupsConsumerGroupIdConsumersGet sync.Mutex
-	ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersGetFunc func(ctx context.Context, clusterId, consumerGroupId string) (command_line_arguments.ConsumerDataList, *net_http.Response, error)
+	ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersGetFunc func(ctx context.Context, clusterId, consumerGroupId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerDataList, *net_http.Response, error)
 
 	lockClustersClusterIdConsumerGroupsConsumerGroupIdGet sync.Mutex
-	ClustersClusterIdConsumerGroupsConsumerGroupIdGetFunc func(ctx context.Context, clusterId, consumerGroupId string) (command_line_arguments.ConsumerGroupData, *net_http.Response, error)
+	ClustersClusterIdConsumerGroupsConsumerGroupIdGetFunc func(ctx context.Context, clusterId, consumerGroupId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerGroupData, *net_http.Response, error)
 
 	lockClustersClusterIdConsumerGroupsConsumerGroupIdLagSummaryGet sync.Mutex
-	ClustersClusterIdConsumerGroupsConsumerGroupIdLagSummaryGetFunc func(ctx context.Context, clusterId, consumerGroupId string) (command_line_arguments.ConsumerGroupLagSummaryData, *net_http.Response, error)
+	ClustersClusterIdConsumerGroupsConsumerGroupIdLagSummaryGetFunc func(ctx context.Context, clusterId, consumerGroupId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerGroupLagSummaryData, *net_http.Response, error)
 
 	lockClustersClusterIdConsumerGroupsConsumerGroupIdLagsGet sync.Mutex
-	ClustersClusterIdConsumerGroupsConsumerGroupIdLagsGetFunc func(ctx context.Context, clusterId, consumerGroupId string) (command_line_arguments.ConsumerLagDataList, *net_http.Response, error)
+	ClustersClusterIdConsumerGroupsConsumerGroupIdLagsGetFunc func(ctx context.Context, clusterId, consumerGroupId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerLagDataList, *net_http.Response, error)
 
 	lockClustersClusterIdConsumerGroupsGet sync.Mutex
-	ClustersClusterIdConsumerGroupsGetFunc func(ctx context.Context, clusterId string) (command_line_arguments.ConsumerGroupDataList, *net_http.Response, error)
+	ClustersClusterIdConsumerGroupsGetFunc func(ctx context.Context, clusterId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerGroupDataList, *net_http.Response, error)
 
 	calls struct {
 		ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsGet []struct {
@@ -86,7 +87,7 @@ type ConsumerGroupApi struct {
 }
 
 // ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsGet mocks base method by wrapping the associated func.
-func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsGet(ctx context.Context, clusterId, consumerGroupId, consumerId string) (command_line_arguments.ConsumerAssignmentDataList, *net_http.Response, error) {
+func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsGet(ctx context.Context, clusterId, consumerGroupId, consumerId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerAssignmentDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsGet.Lock()
 	defer m.lockClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsGet.Unlock()
 
@@ -133,7 +134,7 @@ func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdConsume
 }
 
 // ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsTopicNamePartitionsPartitionIdGet mocks base method by wrapping the associated func.
-func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsTopicNamePartitionsPartitionIdGet(ctx context.Context, clusterId, consumerGroupId, consumerId, topicName string, partitionId int32) (command_line_arguments.ConsumerAssignmentData, *net_http.Response, error) {
+func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsTopicNamePartitionsPartitionIdGet(ctx context.Context, clusterId, consumerGroupId, consumerId, topicName string, partitionId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerAssignmentData, *net_http.Response, error) {
 	m.lockClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsTopicNamePartitionsPartitionIdGet.Lock()
 	defer m.lockClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdAssignmentsTopicNamePartitionsPartitionIdGet.Unlock()
 
@@ -186,7 +187,7 @@ func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdConsume
 }
 
 // ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdGet mocks base method by wrapping the associated func.
-func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdGet(ctx context.Context, clusterId, consumerGroupId, consumerId string) (command_line_arguments.ConsumerData, *net_http.Response, error) {
+func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdGet(ctx context.Context, clusterId, consumerGroupId, consumerId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerData, *net_http.Response, error) {
 	m.lockClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdGet.Lock()
 	defer m.lockClustersClusterIdConsumerGroupsConsumerGroupIdConsumersConsumerIdGet.Unlock()
 
@@ -233,7 +234,7 @@ func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdConsume
 }
 
 // ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersGet mocks base method by wrapping the associated func.
-func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersGet(ctx context.Context, clusterId, consumerGroupId string) (command_line_arguments.ConsumerDataList, *net_http.Response, error) {
+func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdConsumersGet(ctx context.Context, clusterId, consumerGroupId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdConsumerGroupsConsumerGroupIdConsumersGet.Lock()
 	defer m.lockClustersClusterIdConsumerGroupsConsumerGroupIdConsumersGet.Unlock()
 
@@ -277,7 +278,7 @@ func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdConsume
 }
 
 // ClustersClusterIdConsumerGroupsConsumerGroupIdGet mocks base method by wrapping the associated func.
-func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdGet(ctx context.Context, clusterId, consumerGroupId string) (command_line_arguments.ConsumerGroupData, *net_http.Response, error) {
+func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdGet(ctx context.Context, clusterId, consumerGroupId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerGroupData, *net_http.Response, error) {
 	m.lockClustersClusterIdConsumerGroupsConsumerGroupIdGet.Lock()
 	defer m.lockClustersClusterIdConsumerGroupsConsumerGroupIdGet.Unlock()
 
@@ -321,7 +322,7 @@ func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdGetCall
 }
 
 // ClustersClusterIdConsumerGroupsConsumerGroupIdLagSummaryGet mocks base method by wrapping the associated func.
-func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdLagSummaryGet(ctx context.Context, clusterId, consumerGroupId string) (command_line_arguments.ConsumerGroupLagSummaryData, *net_http.Response, error) {
+func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdLagSummaryGet(ctx context.Context, clusterId, consumerGroupId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerGroupLagSummaryData, *net_http.Response, error) {
 	m.lockClustersClusterIdConsumerGroupsConsumerGroupIdLagSummaryGet.Lock()
 	defer m.lockClustersClusterIdConsumerGroupsConsumerGroupIdLagSummaryGet.Unlock()
 
@@ -365,7 +366,7 @@ func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdLagSumm
 }
 
 // ClustersClusterIdConsumerGroupsConsumerGroupIdLagsGet mocks base method by wrapping the associated func.
-func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdLagsGet(ctx context.Context, clusterId, consumerGroupId string) (command_line_arguments.ConsumerLagDataList, *net_http.Response, error) {
+func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdLagsGet(ctx context.Context, clusterId, consumerGroupId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerLagDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdConsumerGroupsConsumerGroupIdLagsGet.Lock()
 	defer m.lockClustersClusterIdConsumerGroupsConsumerGroupIdLagsGet.Unlock()
 
@@ -409,7 +410,7 @@ func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsConsumerGroupIdLagsGet
 }
 
 // ClustersClusterIdConsumerGroupsGet mocks base method by wrapping the associated func.
-func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsGet(ctx context.Context, clusterId string) (command_line_arguments.ConsumerGroupDataList, *net_http.Response, error) {
+func (m *ConsumerGroupApi) ClustersClusterIdConsumerGroupsGet(ctx context.Context, clusterId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerGroupDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdConsumerGroupsGet.Lock()
 	defer m.lockClustersClusterIdConsumerGroupsGet.Unlock()
 

--- a/kafkarestv3/mock/api_partition.go
+++ b/kafkarestv3/mock/api_partition.go
@@ -5,31 +5,32 @@
 package mock
 
 import (
-	command_line_arguments "command-line-arguments"
 	context "context"
 	net_http "net/http"
 	sync "sync"
+
+	github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3 "github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 )
 
 // PartitionApi is a mock of PartitionApi interface
 type PartitionApi struct {
 	lockClustersClusterIdConsumerGroupsConsumerGroupIdLagsTopicNamePartitionsPartitionIdGet sync.Mutex
-	ClustersClusterIdConsumerGroupsConsumerGroupIdLagsTopicNamePartitionsPartitionIdGetFunc func(ctx context.Context, clusterId, consumerGroupId, topicName string, partitionId int32) (command_line_arguments.ConsumerLagData, *net_http.Response, error)
+	ClustersClusterIdConsumerGroupsConsumerGroupIdLagsTopicNamePartitionsPartitionIdGetFunc func(ctx context.Context, clusterId, consumerGroupId, topicName string, partitionId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerLagData, *net_http.Response, error)
 
 	lockClustersClusterIdTopicsPartitionsReassignmentGet sync.Mutex
-	ClustersClusterIdTopicsPartitionsReassignmentGetFunc func(ctx context.Context, clusterId string) (command_line_arguments.ReassignmentDataList, *net_http.Response, error)
+	ClustersClusterIdTopicsPartitionsReassignmentGetFunc func(ctx context.Context, clusterId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ReassignmentDataList, *net_http.Response, error)
 
 	lockClustersClusterIdTopicsTopicNamePartitionsGet sync.Mutex
-	ClustersClusterIdTopicsTopicNamePartitionsGetFunc func(ctx context.Context, clusterId, topicName string) (command_line_arguments.PartitionDataList, *net_http.Response, error)
+	ClustersClusterIdTopicsTopicNamePartitionsGetFunc func(ctx context.Context, clusterId, topicName string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.PartitionDataList, *net_http.Response, error)
 
 	lockClustersClusterIdTopicsTopicNamePartitionsPartitionIdGet sync.Mutex
-	ClustersClusterIdTopicsTopicNamePartitionsPartitionIdGetFunc func(ctx context.Context, clusterId, topicName string, partitionId int32) (command_line_arguments.PartitionData, *net_http.Response, error)
+	ClustersClusterIdTopicsTopicNamePartitionsPartitionIdGetFunc func(ctx context.Context, clusterId, topicName string, partitionId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.PartitionData, *net_http.Response, error)
 
 	lockClustersClusterIdTopicsTopicNamePartitionsPartitionIdReassignmentGet sync.Mutex
-	ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReassignmentGetFunc func(ctx context.Context, clusterId, topicName string, partitionId int32) (command_line_arguments.ReassignmentData, *net_http.Response, error)
+	ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReassignmentGetFunc func(ctx context.Context, clusterId, topicName string, partitionId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ReassignmentData, *net_http.Response, error)
 
 	lockClustersClusterIdTopicsTopicNamePartitionsReassignmentGet sync.Mutex
-	ClustersClusterIdTopicsTopicNamePartitionsReassignmentGetFunc func(ctx context.Context, clusterId, topicName string) (command_line_arguments.ReassignmentDataList, *net_http.Response, error)
+	ClustersClusterIdTopicsTopicNamePartitionsReassignmentGetFunc func(ctx context.Context, clusterId, topicName string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ReassignmentDataList, *net_http.Response, error)
 
 	calls struct {
 		ClustersClusterIdConsumerGroupsConsumerGroupIdLagsTopicNamePartitionsPartitionIdGet []struct {
@@ -69,7 +70,7 @@ type PartitionApi struct {
 }
 
 // ClustersClusterIdConsumerGroupsConsumerGroupIdLagsTopicNamePartitionsPartitionIdGet mocks base method by wrapping the associated func.
-func (m *PartitionApi) ClustersClusterIdConsumerGroupsConsumerGroupIdLagsTopicNamePartitionsPartitionIdGet(ctx context.Context, clusterId, consumerGroupId, topicName string, partitionId int32) (command_line_arguments.ConsumerLagData, *net_http.Response, error) {
+func (m *PartitionApi) ClustersClusterIdConsumerGroupsConsumerGroupIdLagsTopicNamePartitionsPartitionIdGet(ctx context.Context, clusterId, consumerGroupId, topicName string, partitionId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ConsumerLagData, *net_http.Response, error) {
 	m.lockClustersClusterIdConsumerGroupsConsumerGroupIdLagsTopicNamePartitionsPartitionIdGet.Lock()
 	defer m.lockClustersClusterIdConsumerGroupsConsumerGroupIdLagsTopicNamePartitionsPartitionIdGet.Unlock()
 
@@ -119,7 +120,7 @@ func (m *PartitionApi) ClustersClusterIdConsumerGroupsConsumerGroupIdLagsTopicNa
 }
 
 // ClustersClusterIdTopicsPartitionsReassignmentGet mocks base method by wrapping the associated func.
-func (m *PartitionApi) ClustersClusterIdTopicsPartitionsReassignmentGet(ctx context.Context, clusterId string) (command_line_arguments.ReassignmentDataList, *net_http.Response, error) {
+func (m *PartitionApi) ClustersClusterIdTopicsPartitionsReassignmentGet(ctx context.Context, clusterId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ReassignmentDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdTopicsPartitionsReassignmentGet.Lock()
 	defer m.lockClustersClusterIdTopicsPartitionsReassignmentGet.Unlock()
 
@@ -160,7 +161,7 @@ func (m *PartitionApi) ClustersClusterIdTopicsPartitionsReassignmentGetCalls() [
 }
 
 // ClustersClusterIdTopicsTopicNamePartitionsGet mocks base method by wrapping the associated func.
-func (m *PartitionApi) ClustersClusterIdTopicsTopicNamePartitionsGet(ctx context.Context, clusterId, topicName string) (command_line_arguments.PartitionDataList, *net_http.Response, error) {
+func (m *PartitionApi) ClustersClusterIdTopicsTopicNamePartitionsGet(ctx context.Context, clusterId, topicName string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.PartitionDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdTopicsTopicNamePartitionsGet.Lock()
 	defer m.lockClustersClusterIdTopicsTopicNamePartitionsGet.Unlock()
 
@@ -204,7 +205,7 @@ func (m *PartitionApi) ClustersClusterIdTopicsTopicNamePartitionsGetCalls() []st
 }
 
 // ClustersClusterIdTopicsTopicNamePartitionsPartitionIdGet mocks base method by wrapping the associated func.
-func (m *PartitionApi) ClustersClusterIdTopicsTopicNamePartitionsPartitionIdGet(ctx context.Context, clusterId, topicName string, partitionId int32) (command_line_arguments.PartitionData, *net_http.Response, error) {
+func (m *PartitionApi) ClustersClusterIdTopicsTopicNamePartitionsPartitionIdGet(ctx context.Context, clusterId, topicName string, partitionId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.PartitionData, *net_http.Response, error) {
 	m.lockClustersClusterIdTopicsTopicNamePartitionsPartitionIdGet.Lock()
 	defer m.lockClustersClusterIdTopicsTopicNamePartitionsPartitionIdGet.Unlock()
 
@@ -251,7 +252,7 @@ func (m *PartitionApi) ClustersClusterIdTopicsTopicNamePartitionsPartitionIdGetC
 }
 
 // ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReassignmentGet mocks base method by wrapping the associated func.
-func (m *PartitionApi) ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReassignmentGet(ctx context.Context, clusterId, topicName string, partitionId int32) (command_line_arguments.ReassignmentData, *net_http.Response, error) {
+func (m *PartitionApi) ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReassignmentGet(ctx context.Context, clusterId, topicName string, partitionId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ReassignmentData, *net_http.Response, error) {
 	m.lockClustersClusterIdTopicsTopicNamePartitionsPartitionIdReassignmentGet.Lock()
 	defer m.lockClustersClusterIdTopicsTopicNamePartitionsPartitionIdReassignmentGet.Unlock()
 
@@ -298,7 +299,7 @@ func (m *PartitionApi) ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReas
 }
 
 // ClustersClusterIdTopicsTopicNamePartitionsReassignmentGet mocks base method by wrapping the associated func.
-func (m *PartitionApi) ClustersClusterIdTopicsTopicNamePartitionsReassignmentGet(ctx context.Context, clusterId, topicName string) (command_line_arguments.ReassignmentDataList, *net_http.Response, error) {
+func (m *PartitionApi) ClustersClusterIdTopicsTopicNamePartitionsReassignmentGet(ctx context.Context, clusterId, topicName string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ReassignmentDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdTopicsTopicNamePartitionsReassignmentGet.Lock()
 	defer m.lockClustersClusterIdTopicsTopicNamePartitionsReassignmentGet.Unlock()
 

--- a/kafkarestv3/mock/api_replica.go
+++ b/kafkarestv3/mock/api_replica.go
@@ -5,22 +5,23 @@
 package mock
 
 import (
-	command_line_arguments "command-line-arguments"
 	context "context"
 	net_http "net/http"
 	sync "sync"
+
+	github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3 "github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 )
 
 // ReplicaApi is a mock of ReplicaApi interface
 type ReplicaApi struct {
 	lockClustersClusterIdBrokersBrokerIdPartitionReplicasGet sync.Mutex
-	ClustersClusterIdBrokersBrokerIdPartitionReplicasGetFunc func(ctx context.Context, clusterId string, brokerId int32) (command_line_arguments.ReplicaDataList, *net_http.Response, error)
+	ClustersClusterIdBrokersBrokerIdPartitionReplicasGetFunc func(ctx context.Context, clusterId string, brokerId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ReplicaDataList, *net_http.Response, error)
 
 	lockClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasBrokerIdGet sync.Mutex
-	ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasBrokerIdGetFunc func(ctx context.Context, clusterId, topicName string, partitionId, brokerId int32) (command_line_arguments.ReplicaData, *net_http.Response, error)
+	ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasBrokerIdGetFunc func(ctx context.Context, clusterId, topicName string, partitionId, brokerId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ReplicaData, *net_http.Response, error)
 
 	lockClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasGet sync.Mutex
-	ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasGetFunc func(ctx context.Context, clusterId, topicName string, partitionId int32) (command_line_arguments.ReplicaDataList, *net_http.Response, error)
+	ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasGetFunc func(ctx context.Context, clusterId, topicName string, partitionId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ReplicaDataList, *net_http.Response, error)
 
 	calls struct {
 		ClustersClusterIdBrokersBrokerIdPartitionReplicasGet []struct {
@@ -45,7 +46,7 @@ type ReplicaApi struct {
 }
 
 // ClustersClusterIdBrokersBrokerIdPartitionReplicasGet mocks base method by wrapping the associated func.
-func (m *ReplicaApi) ClustersClusterIdBrokersBrokerIdPartitionReplicasGet(ctx context.Context, clusterId string, brokerId int32) (command_line_arguments.ReplicaDataList, *net_http.Response, error) {
+func (m *ReplicaApi) ClustersClusterIdBrokersBrokerIdPartitionReplicasGet(ctx context.Context, clusterId string, brokerId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ReplicaDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdBrokersBrokerIdPartitionReplicasGet.Lock()
 	defer m.lockClustersClusterIdBrokersBrokerIdPartitionReplicasGet.Unlock()
 
@@ -89,7 +90,7 @@ func (m *ReplicaApi) ClustersClusterIdBrokersBrokerIdPartitionReplicasGetCalls()
 }
 
 // ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasBrokerIdGet mocks base method by wrapping the associated func.
-func (m *ReplicaApi) ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasBrokerIdGet(ctx context.Context, clusterId, topicName string, partitionId, brokerId int32) (command_line_arguments.ReplicaData, *net_http.Response, error) {
+func (m *ReplicaApi) ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasBrokerIdGet(ctx context.Context, clusterId, topicName string, partitionId, brokerId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ReplicaData, *net_http.Response, error) {
 	m.lockClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasBrokerIdGet.Lock()
 	defer m.lockClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasBrokerIdGet.Unlock()
 
@@ -139,7 +140,7 @@ func (m *ReplicaApi) ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplic
 }
 
 // ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasGet mocks base method by wrapping the associated func.
-func (m *ReplicaApi) ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasGet(ctx context.Context, clusterId, topicName string, partitionId int32) (command_line_arguments.ReplicaDataList, *net_http.Response, error) {
+func (m *ReplicaApi) ClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasGet(ctx context.Context, clusterId, topicName string, partitionId int32) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ReplicaDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasGet.Lock()
 	defer m.lockClustersClusterIdTopicsTopicNamePartitionsPartitionIdReplicasGet.Unlock()
 

--- a/kafkarestv3/mock/api_topic.go
+++ b/kafkarestv3/mock/api_topic.go
@@ -5,25 +5,26 @@
 package mock
 
 import (
-	command_line_arguments "command-line-arguments"
 	context "context"
 	net_http "net/http"
 	sync "sync"
+
+	github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3 "github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
 )
 
 // TopicApi is a mock of TopicApi interface
 type TopicApi struct {
 	lockClustersClusterIdTopicsGet sync.Mutex
-	ClustersClusterIdTopicsGetFunc func(ctx context.Context, clusterId string) (command_line_arguments.TopicDataList, *net_http.Response, error)
+	ClustersClusterIdTopicsGetFunc func(ctx context.Context, clusterId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.TopicDataList, *net_http.Response, error)
 
 	lockClustersClusterIdTopicsPost sync.Mutex
-	ClustersClusterIdTopicsPostFunc func(ctx context.Context, clusterId string, localVarOptionals *command_line_arguments.ClustersClusterIdTopicsPostOpts) (command_line_arguments.TopicData, *net_http.Response, error)
+	ClustersClusterIdTopicsPostFunc func(ctx context.Context, clusterId string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdTopicsPostOpts) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.TopicData, *net_http.Response, error)
 
 	lockClustersClusterIdTopicsTopicNameDelete sync.Mutex
 	ClustersClusterIdTopicsTopicNameDeleteFunc func(ctx context.Context, clusterId, topicName string) (*net_http.Response, error)
 
 	lockClustersClusterIdTopicsTopicNameGet sync.Mutex
-	ClustersClusterIdTopicsTopicNameGetFunc func(ctx context.Context, clusterId, topicName string) (command_line_arguments.TopicData, *net_http.Response, error)
+	ClustersClusterIdTopicsTopicNameGetFunc func(ctx context.Context, clusterId, topicName string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.TopicData, *net_http.Response, error)
 
 	calls struct {
 		ClustersClusterIdTopicsGet []struct {
@@ -33,7 +34,7 @@ type TopicApi struct {
 		ClustersClusterIdTopicsPost []struct {
 			Ctx               context.Context
 			ClusterId         string
-			LocalVarOptionals *command_line_arguments.ClustersClusterIdTopicsPostOpts
+			LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdTopicsPostOpts
 		}
 		ClustersClusterIdTopicsTopicNameDelete []struct {
 			Ctx       context.Context
@@ -49,7 +50,7 @@ type TopicApi struct {
 }
 
 // ClustersClusterIdTopicsGet mocks base method by wrapping the associated func.
-func (m *TopicApi) ClustersClusterIdTopicsGet(ctx context.Context, clusterId string) (command_line_arguments.TopicDataList, *net_http.Response, error) {
+func (m *TopicApi) ClustersClusterIdTopicsGet(ctx context.Context, clusterId string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.TopicDataList, *net_http.Response, error) {
 	m.lockClustersClusterIdTopicsGet.Lock()
 	defer m.lockClustersClusterIdTopicsGet.Unlock()
 
@@ -90,7 +91,7 @@ func (m *TopicApi) ClustersClusterIdTopicsGetCalls() []struct {
 }
 
 // ClustersClusterIdTopicsPost mocks base method by wrapping the associated func.
-func (m *TopicApi) ClustersClusterIdTopicsPost(ctx context.Context, clusterId string, localVarOptionals *command_line_arguments.ClustersClusterIdTopicsPostOpts) (command_line_arguments.TopicData, *net_http.Response, error) {
+func (m *TopicApi) ClustersClusterIdTopicsPost(ctx context.Context, clusterId string, localVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdTopicsPostOpts) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.TopicData, *net_http.Response, error) {
 	m.lockClustersClusterIdTopicsPost.Lock()
 	defer m.lockClustersClusterIdTopicsPost.Unlock()
 
@@ -101,7 +102,7 @@ func (m *TopicApi) ClustersClusterIdTopicsPost(ctx context.Context, clusterId st
 	call := struct {
 		Ctx               context.Context
 		ClusterId         string
-		LocalVarOptionals *command_line_arguments.ClustersClusterIdTopicsPostOpts
+		LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdTopicsPostOpts
 	}{
 		Ctx:               ctx,
 		ClusterId:         clusterId,
@@ -125,7 +126,7 @@ func (m *TopicApi) ClustersClusterIdTopicsPostCalled() bool {
 func (m *TopicApi) ClustersClusterIdTopicsPostCalls() []struct {
 	Ctx               context.Context
 	ClusterId         string
-	LocalVarOptionals *command_line_arguments.ClustersClusterIdTopicsPostOpts
+	LocalVarOptionals *github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.ClustersClusterIdTopicsPostOpts
 } {
 	m.lockClustersClusterIdTopicsPost.Lock()
 	defer m.lockClustersClusterIdTopicsPost.Unlock()
@@ -178,7 +179,7 @@ func (m *TopicApi) ClustersClusterIdTopicsTopicNameDeleteCalls() []struct {
 }
 
 // ClustersClusterIdTopicsTopicNameGet mocks base method by wrapping the associated func.
-func (m *TopicApi) ClustersClusterIdTopicsTopicNameGet(ctx context.Context, clusterId, topicName string) (command_line_arguments.TopicData, *net_http.Response, error) {
+func (m *TopicApi) ClustersClusterIdTopicsTopicNameGet(ctx context.Context, clusterId, topicName string) (github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3.TopicData, *net_http.Response, error) {
 	m.lockClustersClusterIdTopicsTopicNameGet.Lock()
 	defer m.lockClustersClusterIdTopicsTopicNameGet.Unlock()
 


### PR DESCRIPTION
The `gen-mock` task is deleting the import
```
github_com_confluentinc_kafka_rest_sdk_go_kafkarestv3 "github.com/confluentinc/kafka-rest-sdk-go/kafkarestv3"
```
and replacing it with a nonsense import
```
command_line_arguments "command-line-arguments"
```
due to some mystery go setup issue.

This will revert the import substitutions while keeping the new Consumer Lag API mocks. The mock files technically shouldn't be modified by hand, but I wasn't able to figure out how to get https://github.com/travisjeffery/mocker to correctly create the kafkarestv3 import. For verification, I compared all import-related changes in https://github.com/confluentinc/kafka-rest-sdk-go/pull/8/files with the diff in this PR.

You should be able to confirm that this is the correct output generated by running `make gen-mock`. The mocks should match up in time with kafka-rest commit `f18149a4` (state of the master branch following merge of consumer lag apis).