### PR TITLE
Edit enums values for MirrorTopicStatus.

### DIFF
--- a/kafkarestv3/api/openapi.yaml
+++ b/kafkarestv3/api/openapi.yaml
@@ -10368,7 +10368,7 @@ paths:
                   - partition: 2
                     lag: 40000
                     last_source_fetch_offset: 12030
-                  mirror_status: active
+                  mirror_status: ACTIVE
                   state_time_ms: 1612550939300
                 - kind: KafkaMirrorData
                   metadata:
@@ -10389,7 +10389,7 @@ paths:
                   - partition: 2
                     lag: 40000
                     last_source_fetch_offset: 12030
-                  mirror_status: stopped
+                  mirror_status: STOPPED
                   state_time_ms: 1612551353640
               schema:
                 $ref: '#/components/schemas/ListMirrorTopicsResponseDataList'
@@ -10654,7 +10654,7 @@ paths:
                   - partition: 2
                     lag: 40000
                     last_source_fetch_offset: 12030
-                  mirror_status: active
+                  mirror_status: ACTIVE
                   state_time_ms: 1612550939300
                 - kind: KafkaMirrorData
                   metadata:
@@ -10675,7 +10675,7 @@ paths:
                   - partition: 2
                     lag: 40000
                     last_source_fetch_offset: 12030
-                  mirror_status: stopped
+                  mirror_status: STOPPED
                   state_time_ms: 1612551353640
               schema:
                 $ref: '#/components/schemas/ListMirrorTopicsResponseDataList'
@@ -10821,7 +10821,7 @@ paths:
                 - partition: 2
                   lag: 40000
                   last_source_fetch_offset: 12030
-                mirror_status: active
+                mirror_status: ACTIVE
                 state_time_ms: 1612550939300
               schema:
                 $ref: '#/components/schemas/ListMirrorTopicsResponseData'
@@ -14535,7 +14535,7 @@ components:
               - partition: 2
                 lag: 40000
                 last_source_fetch_offset: 12030
-              mirror_status: active
+              mirror_status: ACTIVE
               state_time_ms: 1612550939300
             - kind: KafkaMirrorData
               metadata:
@@ -14556,7 +14556,7 @@ components:
               - partition: 2
                 lag: 40000
                 last_source_fetch_offset: 12030
-              mirror_status: stopped
+              mirror_status: STOPPED
               state_time_ms: 1612551353640
           schema:
             $ref: '#/components/schemas/ListMirrorTopicsResponseDataList'
@@ -14583,7 +14583,7 @@ components:
             - partition: 2
               lag: 40000
               last_source_fetch_offset: 12030
-            mirror_status: active
+            mirror_status: ACTIVE
             state_time_ms: 1612550939300
           schema:
             $ref: '#/components/schemas/ListMirrorTopicsResponseData'
@@ -15487,11 +15487,11 @@ components:
       type: object
     MirrorTopicStatus:
       enum:
-      - active
-      - failed
-      - paused
-      - stopped
-      - pending_stopped
+      - ACTIVE
+      - FAILED
+      - PAUSED
+      - STOPPED
+      - PENDING_STOPPED
       type: string
     TopicList:
       example:

--- a/kafkarestv3/model_mirror_topic_status.go
+++ b/kafkarestv3/model_mirror_topic_status.go
@@ -29,9 +29,9 @@ type MirrorTopicStatus string
 
 // List of MirrorTopicStatus
 const (
-	MIRRORTOPICSTATUS_ACTIVE          MirrorTopicStatus = "active"
-	MIRRORTOPICSTATUS_FAILED          MirrorTopicStatus = "failed"
-	MIRRORTOPICSTATUS_PAUSED          MirrorTopicStatus = "paused"
-	MIRRORTOPICSTATUS_STOPPED         MirrorTopicStatus = "stopped"
-	MIRRORTOPICSTATUS_PENDING_STOPPED MirrorTopicStatus = "pending_stopped"
+	MIRRORTOPICSTATUS_ACTIVE          MirrorTopicStatus = "ACTIVE"
+	MIRRORTOPICSTATUS_FAILED          MirrorTopicStatus = "FAILED"
+	MIRRORTOPICSTATUS_PAUSED          MirrorTopicStatus = "PAUSED"
+	MIRRORTOPICSTATUS_STOPPED         MirrorTopicStatus = "STOPPED"
+	MIRRORTOPICSTATUS_PENDING_STOPPED MirrorTopicStatus = "PENDING_STOPPED"
 )


### PR DESCRIPTION
### What
Based on https://docs.confluent.io/platform/current/multi-dc-deployments/cluster-linking/mirror-topics-cp.html, the API returns the value in upper case.