### PR TITLE
Generate SDK @ d5e740c.

### DIFF
--- a/kafkarestv3/README.md
+++ b/kafkarestv3/README.md
@@ -63,7 +63,7 @@ Class | Method | HTTP request | Description
 *ClusterLinkingV3Api* | [**ListKafkaMirrorTopicsUnderLink**](docs/ClusterLinkingV3Api.md#listkafkamirrortopicsunderlink) | **Get** /clusters/{cluster_id}/links/{link_name}/mirrors | List mirror topics
 *ClusterLinkingV3Api* | [**ReadKafkaMirrorTopic**](docs/ClusterLinkingV3Api.md#readkafkamirrortopic) | **Get** /clusters/{cluster_id}/links/{link_name}/mirrors/{mirror_topic_name} | Describe the mirror topic
 *ClusterLinkingV3Api* | [**UpdateKafkaLinkConfig**](docs/ClusterLinkingV3Api.md#updatekafkalinkconfig) | **Put** /clusters/{cluster_id}/links/{link_name}/configs/{config_name} | Alter the config under the cluster link
-*ClusterLinkingV3Api* | [**UpdateKafkaLinkConfigBatch**](docs/ClusterLinkingV3Api.md#updatekafkalinkconfigbatch) | **Post** /clusters/{cluster_id}/links/{link_name}/configs:alter | Batch Alter Topic Configs
+*ClusterLinkingV3Api* | [**UpdateKafkaLinkConfigBatch**](docs/ClusterLinkingV3Api.md#updatekafkalinkconfigbatch) | **Put** /clusters/{cluster_id}/links/{link_name}/configs:alter | Batch Alter Topic Configs
 *ClusterLinkingV3Api* | [**UpdateKafkaMirrorTopicsFailover**](docs/ClusterLinkingV3Api.md#updatekafkamirrortopicsfailover) | **Post** /clusters/{cluster_id}/links/{link_name}/mirrors:failover | Failover the mirror topics
 *ClusterLinkingV3Api* | [**UpdateKafkaMirrorTopicsPause**](docs/ClusterLinkingV3Api.md#updatekafkamirrortopicspause) | **Post** /clusters/{cluster_id}/links/{link_name}/mirrors:pause | Pause the mirror topics
 *ClusterLinkingV3Api* | [**UpdateKafkaMirrorTopicsPromote**](docs/ClusterLinkingV3Api.md#updatekafkamirrortopicspromote) | **Post** /clusters/{cluster_id}/links/{link_name}/mirrors:promote | Promote the mirror topics

--- a/kafkarestv3/api/openapi.yaml
+++ b/kafkarestv3/api/openapi.yaml
@@ -10264,7 +10264,7 @@ paths:
       tags:
       - Cluster Linking (v3)
   /clusters/{cluster_id}/links/{link_name}/configs:alter:
-    post:
+    put:
       description: |-
         [![Generally Available](https://img.shields.io/badge/Lifecycle%20Stage-Generally%20Available-%2345c6e8)](#section/Versioning/API-Lifecycle-Policy)
 
@@ -10418,7 +10418,7 @@ paths:
         style: simple
       - description: The status of the mirror topic. If not specified, all mirror
           topics will be returned.
-        example: active
+        example: ACTIVE
         explode: true
         in: query
         name: mirror_status
@@ -10456,7 +10456,7 @@ paths:
                   - partition: 2
                     lag: 40000
                     last_source_fetch_offset: 12030
-                  mirror_topic_status: active
+                  mirror_status: ACTIVE
                   state_time_ms: 1612550939300
                 - kind: KafkaMirrorData
                   metadata:
@@ -10477,7 +10477,7 @@ paths:
                   - partition: 2
                     lag: 40000
                     last_source_fetch_offset: 12030
-                  mirror_topic_status: stopped
+                  mirror_status: STOPPED
                   state_time_ms: 1612551353640
               schema:
                 $ref: '#/components/schemas/ListMirrorTopicsResponseDataList'
@@ -10704,7 +10704,7 @@ paths:
         style: simple
       - description: The status of the mirror topic. If not specified, all mirror
           topics will be returned.
-        example: active
+        example: ACTIVE
         explode: true
         in: query
         name: mirror_status
@@ -10742,7 +10742,7 @@ paths:
                   - partition: 2
                     lag: 40000
                     last_source_fetch_offset: 12030
-                  mirror_topic_status: active
+                  mirror_status: ACTIVE
                   state_time_ms: 1612550939300
                 - kind: KafkaMirrorData
                   metadata:
@@ -10763,7 +10763,7 @@ paths:
                   - partition: 2
                     lag: 40000
                     last_source_fetch_offset: 12030
-                  mirror_topic_status: stopped
+                  mirror_status: STOPPED
                   state_time_ms: 1612551353640
               schema:
                 $ref: '#/components/schemas/ListMirrorTopicsResponseDataList'
@@ -10909,7 +10909,7 @@ paths:
                 - partition: 2
                   lag: 40000
                   last_source_fetch_offset: 12030
-                mirror_topic_status: active
+                mirror_status: ACTIVE
                 state_time_ms: 1612550939300
               schema:
                 $ref: '#/components/schemas/ListMirrorTopicsResponseData'
@@ -12411,7 +12411,7 @@ components:
     MirrorTopicStatus:
       description: The status of the mirror topic. If not specified, all mirror topics
         will be returned.
-      example: active
+      example: ACTIVE
       explode: true
       in: query
       name: mirror_status
@@ -14689,7 +14689,7 @@ components:
               - partition: 2
                 lag: 40000
                 last_source_fetch_offset: 12030
-              mirror_topic_status: active
+              mirror_status: ACTIVE
               state_time_ms: 1612550939300
             - kind: KafkaMirrorData
               metadata:
@@ -14710,7 +14710,7 @@ components:
               - partition: 2
                 lag: 40000
                 last_source_fetch_offset: 12030
-              mirror_topic_status: stopped
+              mirror_status: STOPPED
               state_time_ms: 1612551353640
           schema:
             $ref: '#/components/schemas/ListMirrorTopicsResponseDataList'
@@ -14737,7 +14737,7 @@ components:
             - partition: 2
               lag: 40000
               last_source_fetch_offset: 12030
-            mirror_topic_status: active
+            mirror_status: ACTIVE
             state_time_ms: 1612550939300
           schema:
             $ref: '#/components/schemas/ListMirrorTopicsResponseData'
@@ -15669,6 +15669,7 @@ components:
         partition:
           type: integer
         lag:
+          format: int64
           type: integer
         last_source_fetch_offset:
           format: int64
@@ -15680,11 +15681,11 @@ components:
       type: object
     MirrorTopicStatus:
       enum:
-      - active
-      - failed
-      - paused
-      - stopped
-      - pending_stopped
+      - ACTIVE
+      - FAILED
+      - PAUSED
+      - STOPPED
+      - PENDING_STOPPED
       type: string
     TopicList:
       example:
@@ -16777,15 +16778,16 @@ components:
           items:
             $ref: '#/components/schemas/MirrorLag'
           type: array
-        mirror_topic_status:
+        mirror_status:
           $ref: '#/components/schemas/MirrorTopicStatus'
         state_time_ms:
+          format: int64
           type: integer
       required:
       - link_name
       - mirror_lags
+      - mirror_status
       - mirror_topic_name
-      - mirror_topic_status
       - num_partitions
       - source_topic_name
       - state_time_ms

--- a/kafkarestv3/api_cluster_linking_v3.go
+++ b/kafkarestv3/api_cluster_linking_v3.go
@@ -1801,7 +1801,7 @@ type UpdateKafkaLinkConfigBatchOpts struct {
  */
 func (a *ClusterLinkingV3ApiService) UpdateKafkaLinkConfigBatch(ctx _context.Context, clusterId string, linkName string, localVarOptionals *UpdateKafkaLinkConfigBatchOpts) (*_nethttp.Response, error) {
 	var (
-		localVarHTTPMethod   = _nethttp.MethodPost
+		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
 		localVarFormFileName string
 		localVarFileName     string

--- a/kafkarestv3/docs/ClusterLinkingV3Api.md
+++ b/kafkarestv3/docs/ClusterLinkingV3Api.md
@@ -16,7 +16,7 @@ Method | HTTP request | Description
 [**ListKafkaMirrorTopicsUnderLink**](ClusterLinkingV3Api.md#ListKafkaMirrorTopicsUnderLink) | **Get** /clusters/{cluster_id}/links/{link_name}/mirrors | List mirror topics
 [**ReadKafkaMirrorTopic**](ClusterLinkingV3Api.md#ReadKafkaMirrorTopic) | **Get** /clusters/{cluster_id}/links/{link_name}/mirrors/{mirror_topic_name} | Describe the mirror topic
 [**UpdateKafkaLinkConfig**](ClusterLinkingV3Api.md#UpdateKafkaLinkConfig) | **Put** /clusters/{cluster_id}/links/{link_name}/configs/{config_name} | Alter the config under the cluster link
-[**UpdateKafkaLinkConfigBatch**](ClusterLinkingV3Api.md#UpdateKafkaLinkConfigBatch) | **Post** /clusters/{cluster_id}/links/{link_name}/configs:alter | Batch Alter Topic Configs
+[**UpdateKafkaLinkConfigBatch**](ClusterLinkingV3Api.md#UpdateKafkaLinkConfigBatch) | **Put** /clusters/{cluster_id}/links/{link_name}/configs:alter | Batch Alter Topic Configs
 [**UpdateKafkaMirrorTopicsFailover**](ClusterLinkingV3Api.md#UpdateKafkaMirrorTopicsFailover) | **Post** /clusters/{cluster_id}/links/{link_name}/mirrors:failover | Failover the mirror topics
 [**UpdateKafkaMirrorTopicsPause**](ClusterLinkingV3Api.md#UpdateKafkaMirrorTopicsPause) | **Post** /clusters/{cluster_id}/links/{link_name}/mirrors:pause | Pause the mirror topics
 [**UpdateKafkaMirrorTopicsPromote**](ClusterLinkingV3Api.md#UpdateKafkaMirrorTopicsPromote) | **Post** /clusters/{cluster_id}/links/{link_name}/mirrors:promote | Promote the mirror topics

--- a/kafkarestv3/docs/ListMirrorTopicsResponseData.md
+++ b/kafkarestv3/docs/ListMirrorTopicsResponseData.md
@@ -11,8 +11,8 @@ Name | Type | Description | Notes
 **SourceTopicName** | **string** |  | 
 **NumPartitions** | **int32** |  | 
 **MirrorLags** | [**[]MirrorLag**](MirrorLag.md) |  | 
-**MirrorTopicStatus** | [**MirrorTopicStatus**](MirrorTopicStatus.md) |  | 
-**StateTimeMs** | **int32** |  | 
+**MirrorStatus** | [**MirrorTopicStatus**](MirrorTopicStatus.md) |  | 
+**StateTimeMs** | **int64** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/kafkarestv3/docs/ListMirrorTopicsResponseDataAllOf.md
+++ b/kafkarestv3/docs/ListMirrorTopicsResponseDataAllOf.md
@@ -9,8 +9,8 @@ Name | Type | Description | Notes
 **SourceTopicName** | **string** |  | 
 **NumPartitions** | **int32** |  | 
 **MirrorLags** | [**[]MirrorLag**](MirrorLag.md) |  | 
-**MirrorTopicStatus** | [**MirrorTopicStatus**](MirrorTopicStatus.md) |  | 
-**StateTimeMs** | **int32** |  | 
+**MirrorStatus** | [**MirrorTopicStatus**](MirrorTopicStatus.md) |  | 
+**StateTimeMs** | **int64** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/kafkarestv3/docs/MirrorLag.md
+++ b/kafkarestv3/docs/MirrorLag.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Partition** | **int32** |  | 
-**Lag** | **int32** |  | 
+**Lag** | **int64** |  | 
 **LastSourceFetchOffset** | **int64** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/kafkarestv3/model_list_mirror_topics_response_data.go
+++ b/kafkarestv3/model_list_mirror_topics_response_data.go
@@ -26,13 +26,13 @@ package kafkarestv3
 
 // ListMirrorTopicsResponseData struct for ListMirrorTopicsResponseData
 type ListMirrorTopicsResponseData struct {
-	Kind              string            `json:"kind"`
-	Metadata          ResourceMetadata  `json:"metadata"`
-	LinkName          string            `json:"link_name"`
-	MirrorTopicName   string            `json:"mirror_topic_name"`
-	SourceTopicName   string            `json:"source_topic_name"`
-	NumPartitions     int32             `json:"num_partitions"`
-	MirrorLags        []MirrorLag       `json:"mirror_lags"`
-	MirrorTopicStatus MirrorTopicStatus `json:"mirror_topic_status"`
-	StateTimeMs       int32             `json:"state_time_ms"`
+	Kind            string            `json:"kind"`
+	Metadata        ResourceMetadata  `json:"metadata"`
+	LinkName        string            `json:"link_name"`
+	MirrorTopicName string            `json:"mirror_topic_name"`
+	SourceTopicName string            `json:"source_topic_name"`
+	NumPartitions   int32             `json:"num_partitions"`
+	MirrorLags      []MirrorLag       `json:"mirror_lags"`
+	MirrorStatus    MirrorTopicStatus `json:"mirror_status"`
+	StateTimeMs     int64             `json:"state_time_ms"`
 }

--- a/kafkarestv3/model_list_mirror_topics_response_data_all_of.go
+++ b/kafkarestv3/model_list_mirror_topics_response_data_all_of.go
@@ -26,11 +26,11 @@ package kafkarestv3
 
 // ListMirrorTopicsResponseDataAllOf struct for ListMirrorTopicsResponseDataAllOf
 type ListMirrorTopicsResponseDataAllOf struct {
-	LinkName          string            `json:"link_name"`
-	MirrorTopicName   string            `json:"mirror_topic_name"`
-	SourceTopicName   string            `json:"source_topic_name"`
-	NumPartitions     int32             `json:"num_partitions"`
-	MirrorLags        []MirrorLag       `json:"mirror_lags"`
-	MirrorTopicStatus MirrorTopicStatus `json:"mirror_topic_status"`
-	StateTimeMs       int32             `json:"state_time_ms"`
+	LinkName        string            `json:"link_name"`
+	MirrorTopicName string            `json:"mirror_topic_name"`
+	SourceTopicName string            `json:"source_topic_name"`
+	NumPartitions   int32             `json:"num_partitions"`
+	MirrorLags      []MirrorLag       `json:"mirror_lags"`
+	MirrorStatus    MirrorTopicStatus `json:"mirror_status"`
+	StateTimeMs     int64             `json:"state_time_ms"`
 }

--- a/kafkarestv3/model_mirror_lag.go
+++ b/kafkarestv3/model_mirror_lag.go
@@ -27,6 +27,6 @@ package kafkarestv3
 // MirrorLag struct for MirrorLag
 type MirrorLag struct {
 	Partition             int32 `json:"partition"`
-	Lag                   int32 `json:"lag"`
+	Lag                   int64 `json:"lag"`
 	LastSourceFetchOffset int64 `json:"last_source_fetch_offset"`
 }

--- a/kafkarestv3/model_mirror_topic_status.go
+++ b/kafkarestv3/model_mirror_topic_status.go
@@ -29,9 +29,9 @@ type MirrorTopicStatus string
 
 // List of MirrorTopicStatus
 const (
-	MIRRORTOPICSTATUS_ACTIVE          MirrorTopicStatus = "active"
-	MIRRORTOPICSTATUS_FAILED          MirrorTopicStatus = "failed"
-	MIRRORTOPICSTATUS_PAUSED          MirrorTopicStatus = "paused"
-	MIRRORTOPICSTATUS_STOPPED         MirrorTopicStatus = "stopped"
-	MIRRORTOPICSTATUS_PENDING_STOPPED MirrorTopicStatus = "pending_stopped"
+	MIRRORTOPICSTATUS_ACTIVE          MirrorTopicStatus = "ACTIVE"
+	MIRRORTOPICSTATUS_FAILED          MirrorTopicStatus = "FAILED"
+	MIRRORTOPICSTATUS_PAUSED          MirrorTopicStatus = "PAUSED"
+	MIRRORTOPICSTATUS_STOPPED         MirrorTopicStatus = "STOPPED"
+	MIRRORTOPICSTATUS_PENDING_STOPPED MirrorTopicStatus = "PENDING_STOPPED"
 )


### PR DESCRIPTION
### What
Regenerate SDK based on new changes from https://github.com/confluentinc/ce-kafka-rest/pull/295

### References
https://confluent.slack.com/archives/C010Y0EP5MZ/p1645125217291669?thread_ts=1645084687.807989&cid=C010Y0EP5MZ

### Note
I did try to regenerate mock: 
```
mocker --prefix "" --dst mock/api_cluster_linking_v3.go --pkg mock    api_cluster_linking_v3.go ClusterLinkingV3Api
```
but it shows no changes so 🤷 