### PR TITLE
KGLOBAL-3306: Regenerate SDK to change topics_names to topic_names

### DIFF
--- a/kafkarestv3/api/openapi.yaml
+++ b/kafkarestv3/api/openapi.yaml
@@ -9581,7 +9581,7 @@ paths:
                   link_name: my-new-link-3
                   link_id: 9cd1711e-a4ef-4390-a35e-dfd758d97a82
                   cluster_link_id: nNFxHqTvQ5CjXt_XWNl6gg
-                  topic_names: null
+                  topic_names: []
               schema:
                 $ref: '#/components/schemas/ListLinksResponseDataList'
           description: A list of link names and properties
@@ -10014,7 +10014,7 @@ paths:
                     link_name: my-new-link-1
                     link_id: 7840644d-f7d8-4844-a577-a10ef3df31df
                     cluster_link_id: eEBkTffYSESld6EO898x3w
-                    topic_names: null
+                    topic_names: []
               schema:
                 $ref: '#/components/schemas/ListLinksResponseData'
           description: Single link name and properties
@@ -15286,7 +15286,7 @@ components:
               link_name: my-new-link-3
               link_id: 9cd1711e-a4ef-4390-a35e-dfd758d97a82
               cluster_link_id: nNFxHqTvQ5CjXt_XWNl6gg
-              topic_names: null
+              topic_names: []
           schema:
             $ref: '#/components/schemas/ListLinksResponseDataList'
       description: A list of link names and properties
@@ -15321,7 +15321,7 @@ components:
                 link_name: my-new-link-1
                 link_id: 7840644d-f7d8-4844-a577-a10ef3df31df
                 cluster_link_id: eEBkTffYSESld6EO898x3w
-                topic_names: null
+                topic_names: []
           schema:
             $ref: '#/components/schemas/ListLinksResponseData'
       description: Single link name and properties
@@ -17464,7 +17464,7 @@ components:
           type: string
         cluster_link_id:
           type: string
-        topics_names:
+        topic_names:
           items:
             type: string
           type: array

--- a/kafkarestv3/docs/ListLinksResponseData.md
+++ b/kafkarestv3/docs/ListLinksResponseData.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **LinkName** | **string** |  | 
 **LinkId** | **string** |  | 
 **ClusterLinkId** | **string** |  | 
-**TopicsNames** | **[]string** |  | [optional] 
+**TopicNames** | **[]string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/kafkarestv3/docs/ListLinksResponseDataAllOf.md
+++ b/kafkarestv3/docs/ListLinksResponseDataAllOf.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **LinkName** | **string** |  | 
 **LinkId** | **string** |  | 
 **ClusterLinkId** | **string** |  | 
-**TopicsNames** | **[]string** |  | [optional] 
+**TopicNames** | **[]string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/kafkarestv3/model_list_links_response_data.go
+++ b/kafkarestv3/model_list_links_response_data.go
@@ -19,5 +19,5 @@ type ListLinksResponseData struct {
 	LinkName             string           `json:"link_name"`
 	LinkId               string           `json:"link_id"`
 	ClusterLinkId        string           `json:"cluster_link_id"`
-	TopicsNames          []string         `json:"topics_names,omitempty"`
+	TopicNames           []string         `json:"topic_names"`
 }

--- a/kafkarestv3/model_list_links_response_data_all_of.go
+++ b/kafkarestv3/model_list_links_response_data_all_of.go
@@ -17,5 +17,5 @@ type ListLinksResponseDataAllOf struct {
 	LinkName             string   `json:"link_name"`
 	LinkId               string   `json:"link_id"`
 	ClusterLinkId        string   `json:"cluster_link_id"`
-	TopicsNames          []string `json:"topics_names,omitempty"`
+	TopicNames           []string `json:"topic_names"`
 }


### PR DESCRIPTION
Regenerate SDK using ce-kafka-rest/commit/e2e524e0e626424f409866353a386a22e1ccf105 and fix for KGLOBAL-3306 https://github.com/confluentinc/ce-kafka-rest/commit/9b604f7e69a59c4d74366a1e42f5fb5a20ad7e8b